### PR TITLE
fix: keep native tabs below splash overlays

### DIFF
--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -553,7 +553,7 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
 
         if let parent = bridge?.viewController {
             parent.addChild(controller)
-            parent.view.addSubview(controller.view)
+            insertSystemTabControllerView(controller.view, in: parent.view)
             controller.didMove(toParent: parent)
         }
 
@@ -631,6 +631,43 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         originalWebViewSuperview = superview
         originalWebViewIndex = superview.subviews.firstIndex(of: webView)
         originalWebViewAutoresizingMask = webView.autoresizingMask
+    }
+
+    private func insertSystemTabControllerView(_ controllerView: UIView, in parentView: UIView) {
+        guard let webView = webView else {
+            parentView.addSubview(controllerView)
+            return
+        }
+
+        captureOriginalWebViewPlacementIfNeeded(webView)
+        let insertionIndex = systemTabControllerInsertionIndex(in: parentView, for: webView)
+        parentView.insertSubview(controllerView, at: insertionIndex)
+    }
+
+    private func systemTabControllerInsertionIndex(in parentView: UIView, for webView: UIView) -> Int {
+        if let directChild = directChild(of: parentView, containing: webView),
+           let index = parentView.subviews.firstIndex(of: directChild) {
+            return min(index, parentView.subviews.count)
+        }
+
+        if let originalWebViewSuperview = originalWebViewSuperview,
+           originalWebViewSuperview === parentView {
+            return min(originalWebViewIndex ?? parentView.subviews.count, parentView.subviews.count)
+        }
+
+        return parentView.subviews.count
+    }
+
+    private func directChild(of ancestor: UIView, containing descendant: UIView) -> UIView? {
+        var current: UIView? = descendant
+        while let view = current, let superview = view.superview {
+            if superview === ancestor {
+                return view
+            }
+            current = superview
+        }
+
+        return nil
     }
 
     private func hostWebViewInSelectedSystemTab() {


### PR DESCRIPTION
## Summary
- insert the iOS system tab host at the WebView's original root-view position instead of always adding it above existing views
- preserve startup overlays like Capacitor SplashScreen above native Liquid Glass tabs until they are hidden

## Verification
- bun run lint
- bun run verify:ios
- bun run verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed system tab bar positioning in iOS navigation to ensure it appears in the correct location within the app's view hierarchy, maintaining proper ordering relative to web views and other interface elements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/6)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->