### PR TITLE
fix: align iOS package names with Capacitor

### DIFF
--- a/CapgoCapacitorNativeNavigation.podspec
+++ b/CapgoCapacitorNativeNavigation.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapgoNativeNavigation'
+  s.name = 'CapgoCapacitorNativeNavigation'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapgoNativeNavigation",
+    name: "CapgoCapacitorNativeNavigation",
     platforms: [.iOS(.v15)],
     products: [
         .library(
-            name: "CapgoNativeNavigation",
+            name: "CapgoCapacitorNativeNavigation",
             targets: ["NativeNavigationPlugin"])
     ],
     dependencies: [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapgoNativeNavigation.podspec"
+    "CapgoCapacitorNativeNavigation.podspec"
   ],
   "author": "Martin Donadieu <martin@capgo.app>",
   "license": "MPL-2.0",
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoNativeNavigation -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorNativeNavigation -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "bun run build",
     "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -9,6 +9,7 @@
  *
  * And (when iOS is declared in package.json capacitor config):
  * - CocoaPods podspec s.name matches SwiftPM Package(name: ...) and .library(name: ...)
+ * - iOS package/spec names match Capacitor's normalized npm package name
  *
  * Usage:
  *   node scripts/check-capacitor-plugin-wiring.mjs            # checks current working dir
@@ -86,6 +87,20 @@ function uniq(arr) {
   return out;
 }
 
+function upperFirst(s) {
+  return s ? `${s[0].toUpperCase()}${s.slice(1)}` : "";
+}
+
+function packageNameToCapacitorIosName(packageName) {
+  return packageName
+    .replace(/^@/, "")
+    .split("/")
+    .flatMap((part) => part.split(/[^A-Za-z0-9]+/))
+    .filter(Boolean)
+    .map((part) => upperFirst(part))
+    .join("");
+}
+
 function parseArgs(argv) {
   const out = { dir: process.cwd() };
   for (let i = 2; i < argv.length; i++) {
@@ -118,6 +133,7 @@ try {
 const cap = typeof pkg.capacitor === "object" && pkg.capacitor ? pkg.capacitor : {};
 const supportsAndroid = typeof cap.android === "object" && cap.android;
 const supportsIos = typeof cap.ios === "object" && cap.ios;
+const expectedIosName = packageNameToCapacitorIosName(pkg.name || "");
 
 // Not a Capacitor plugin package (e.g. meta/workspace package).
 // We only enforce wiring rules for actual plugin packages declaring a `capacitor` config.
@@ -233,8 +249,18 @@ if (supportsIos) {
   } else if (podspecs.length) {
     const podName = parsePodspecName(podspecs[0]);
     const { pkgName, libNames } = parseSpmNames(pkgSwift);
+    const podspecFileName = path.basename(podspecs[0], ".podspec");
     if (!podName) errors.push("Podspec: missing s.name = '...'");
     if (!pkgName) errors.push('SPM: missing Package(name: "...")');
+    if (expectedIosName && podspecFileName !== expectedIosName) {
+      errors.push(`Podspec: filename=${podspecFileName}.podspec != Capacitor iOS package name ${expectedIosName}`);
+    }
+    if (expectedIosName && podName && podName !== expectedIosName) {
+      errors.push(`Podspec: s.name=${podName} != Capacitor iOS package name ${expectedIosName}`);
+    }
+    if (expectedIosName && pkgName && pkgName !== expectedIosName) {
+      errors.push(`SPM: Package(name)=${pkgName} != Capacitor iOS package name ${expectedIosName}`);
+    }
     if (podName && pkgName && podName !== pkgName) {
       errors.push(`Podspec: s.name=${podName} != Package(name)=${pkgName}`);
     }


### PR DESCRIPTION
## Summary
- rename the SwiftPM package/product to `CapgoCapacitorNativeNavigation`, matching Capacitor's normalized iOS name for `@capgo/capacitor-native-navigation`
- rename the CocoaPods spec and published package file entry to the same iOS name
- extend the wiring checker to validate podspec/SPM names against the normalized npm package name

Fixes #7.

## Checks
- `bun run check:wiring`
- `bun run build`
- `bun run eslint`
- `bun run prettier -- --check`
- `git diff --check`

## Not run
- `bun run verify:ios` requires `xcodebuild`, which is not available in this Linux environment
- `bun run verify:android` is blocked here by Java 8; Android Gradle plugin 8.13.0 requires Java 11+


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package naming for consistency across iOS dependency management systems.
  * Enhanced build validation to enforce iOS package configuration consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->