### PR TITLE
fix: align iOS package name with Capacitor

### DIFF
--- a/CapgoCapacitorNativeNavigation.podspec
+++ b/CapgoCapacitorNativeNavigation.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapgoNativeNavigation'
+  s.name = 'CapgoCapacitorNativeNavigation'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapgoNativeNavigation",
+    name: "CapgoCapacitorNativeNavigation",
     platforms: [.iOS(.v15)],
     products: [
         .library(
-            name: "CapgoNativeNavigation",
+            name: "CapgoCapacitorNativeNavigation",
             targets: ["NativeNavigationPlugin"])
     ],
     dependencies: [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapgoNativeNavigation.podspec"
+    "CapgoCapacitorNativeNavigation.podspec"
   ],
   "author": "Martin Donadieu <martin@capgo.app>",
   "license": "MPL-2.0",
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoNativeNavigation -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorNativeNavigation -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "bun run build",
     "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -9,6 +9,7 @@
  *
  * And (when iOS is declared in package.json capacitor config):
  * - CocoaPods podspec s.name matches SwiftPM Package(name: ...) and .library(name: ...)
+ * - iOS package names match Capacitor's normalized npm package name
  *
  * Usage:
  *   node scripts/check-capacitor-plugin-wiring.mjs            # checks current working dir
@@ -84,6 +85,18 @@ function uniq(arr) {
     if (!out.includes(x)) out.push(x);
   }
   return out;
+}
+
+function capacitorPluginName(packageName) {
+  if (typeof packageName !== "string" || !packageName) return "";
+
+  const name = packageName
+    .replace(/\//g, "_")
+    .replace(/-/g, "_")
+    .replace(/@/g, "")
+    .replace(/_\w/g, (match) => match[1].toUpperCase());
+
+  return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
 function parseArgs(argv) {
@@ -232,14 +245,28 @@ if (supportsIos) {
     errors.push("iOS: missing Package.swift at plugin root");
   } else if (podspecs.length) {
     const podName = parsePodspecName(podspecs[0]);
+    const podFileName = path.basename(podspecs[0], ".podspec");
     const { pkgName, libNames } = parseSpmNames(pkgSwift);
+    const expectedIosName = capacitorPluginName(pkg.name);
     if (!podName) errors.push("Podspec: missing s.name = '...'");
+    if (podName && podFileName !== podName) {
+      errors.push(`Podspec: filename ${podFileName}.podspec != s.name ${podName}`);
+    }
     if (!pkgName) errors.push('SPM: missing Package(name: "...")');
     if (podName && pkgName && podName !== pkgName) {
       errors.push(`Podspec: s.name=${podName} != Package(name)=${pkgName}`);
     }
+    if (expectedIosName && podName && podName !== expectedIosName) {
+      errors.push(`Podspec: s.name=${podName} != Capacitor expected iOS package name ${expectedIosName}`);
+    }
+    if (expectedIosName && pkgName && pkgName !== expectedIosName) {
+      errors.push(`SPM: Package(name)=${pkgName} != Capacitor expected iOS package name ${expectedIosName}`);
+    }
     if (pkgName && libNames.length && !libNames.includes(pkgName)) {
       errors.push(`SPM: Package(name)=${pkgName} not present in .library(name) list ${JSON.stringify(libNames)}`);
+    }
+    if (expectedIosName && libNames.length && !libNames.includes(expectedIosName)) {
+      errors.push(`SPM: expected library product ${expectedIosName} not present in .library(name) list ${JSON.stringify(libNames)}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- rename the SwiftPM package and library product to Capacitor's normalized plugin name: `CapgoCapacitorNativeNavigation`
- rename the CocoaPods podspec and `s.name` to the same iOS package name
- update the wiring guard to derive and enforce Capacitor's expected iOS package name from `package.json`, including the podspec filename

## Verification
- `bun run check:wiring`
- `bun run verify:ios`
- `bun run lint`
- `bun run verify`
- confirmed Capacitor CLI normalizes `@capgo/capacitor-native-navigation` to `CapgoCapacitorNativeNavigation`

Fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package naming across all iOS build configuration files (CocoaPods podspec, Swift Package Manager manifest, and npm package definition) to ensure consistency with Capacitor plugin naming standards.
  * Improved build validation to automatically verify iOS package naming is correctly applied across CocoaPods, Swift Package Manager, and npm package manifests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->