### PR TITLE
fix: prevent iOS system tab layer cycle

### DIFF
--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -44,6 +44,7 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
     private var tabBar: UITabBar?
     private var tabBarController: NativeNavigationTabController?
     private var tabViewControllers: [UIViewController] = []
+    private weak var systemTabRootContainer: UIView?
     private weak var originalWebViewSuperview: UIView?
     private var originalWebViewIndex: Int?
     private var originalWebViewAutoresizingMask: UIView.AutoresizingMask?
@@ -552,8 +553,9 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         controller.view.isHidden = !tabbarVisible
 
         if let parent = bridge?.viewController {
+            let containerView = systemTabHostingContainerView(in: parent)
             parent.addChild(controller)
-            insertSystemTabControllerView(controller.view, in: parent.view)
+            insertSystemTabControllerView(controller.view, in: containerView)
             controller.didMove(toParent: parent)
         }
 
@@ -561,6 +563,49 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         self.tabBar = controller.tabBar
         hostWebViewInSelectedSystemTab()
         return controller.tabBar
+    }
+
+    private func systemTabHostingContainerView(in parent: UIViewController) -> UIView {
+        if let systemTabRootContainer = systemTabRootContainer {
+            return systemTabRootContainer
+        }
+
+        guard let webView = webView,
+              parent.view === webView else {
+            return parent.view
+        }
+
+        let previousSuperview = webView.superview
+        let previousIndex = previousSuperview?.subviews.firstIndex(of: webView)
+        let previousFrame = webView.frame
+        let previousAutoresizingMask = webView.autoresizingMask
+        let container = UIView(frame: previousFrame)
+        container.backgroundColor = .clear
+        container.isOpaque = false
+        container.autoresizingMask = previousAutoresizingMask.isEmpty ? [.flexibleWidth, .flexibleHeight] : previousAutoresizingMask
+
+        if let previousSuperview = previousSuperview {
+            previousSuperview.insertSubview(container, at: min(previousIndex ?? previousSuperview.subviews.count, previousSuperview.subviews.count))
+        }
+
+        parent.view = container
+        container.addSubview(webView)
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        webView.frame = container.bounds
+        moveNativeChrome(from: webView, to: container)
+
+        systemTabRootContainer = container
+        originalWebViewSuperview = container
+        originalWebViewIndex = 0
+        originalWebViewAutoresizingMask = webView.autoresizingMask
+        return container
+    }
+
+    private func moveNativeChrome(from webView: UIView, to container: UIView) {
+        if let navContainer = navContainer,
+           navContainer.superview === webView {
+            container.addSubview(navContainer)
+        }
     }
 
     private func applySystemTabBarItems(_ items: [UITabBarItem], selectedIndex: Int?, animated: Bool) {
@@ -679,7 +724,10 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
 
         captureOriginalWebViewPlacementIfNeeded(webView)
         clearHostedWebViews(matching: webView, except: selectedController)
-        selectedController.host(webView: webView)
+        guard selectedController.host(webView: webView) else {
+            isWebViewHostedInSystemTabController = false
+            return
+        }
         clearHostedWebViews(matching: webView, except: selectedController)
         isWebViewHostedInSystemTabController = true
     }
@@ -1367,7 +1415,7 @@ private final class NativeNavigationBar: UINavigationBar {
     }
 }
 
-private final class NativeNavigationTabController: UITabBarController {
+final class NativeNavigationTabController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .clear
@@ -1376,7 +1424,7 @@ private final class NativeNavigationTabController: UITabBarController {
     }
 }
 
-private final class NativeNavigationTabContentController: UIViewController {
+final class NativeNavigationTabContentController: UIViewController {
     private weak var hostedWebView: UIView?
 
     override func loadView() {
@@ -1402,16 +1450,21 @@ private final class NativeNavigationTabContentController: UIViewController {
         hostedWebView = nil
     }
 
-    func host(webView: UIView) {
-        if hostedWebView !== webView {
-            hostedWebView = webView
+    @discardableResult
+    func host(webView: UIView) -> Bool {
+        guard view !== webView, !view.isDescendant(of: webView) else {
+            hostedWebView = nil
+            return false
         }
+
+        hostedWebView = webView
         if webView.superview !== view {
             webView.removeFromSuperview()
             view.addSubview(webView)
         }
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         webView.frame = view.bounds
+        return true
     }
 }
 

--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -438,6 +438,13 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         notifyTabSelect(index: item.tag)
     }
 
+    public func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        if usesSystemLiquidGlass {
+            hostWebView(in: viewController)
+        }
+        return true
+    }
+
     public func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
         guard !suppressTabSelectEvent else {
             hostWebViewInSelectedSystemTab()
@@ -580,8 +587,8 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         let previousFrame = webView.frame
         let previousAutoresizingMask = webView.autoresizingMask
         let container = UIView(frame: previousFrame)
-        container.backgroundColor = .clear
-        container.isOpaque = false
+        container.backgroundColor = nativeNavigationFallbackBackground(for: webView)
+        container.isOpaque = true
         container.autoresizingMask = previousAutoresizingMask.isEmpty ? [.flexibleWidth, .flexibleHeight] : previousAutoresizingMask
 
         if let previousSuperview = previousSuperview {
@@ -614,24 +621,43 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         }
 
         let previousSelectedIndex = tabBarController.selectedIndex
-        let controllers = items.map { item -> UIViewController in
+        let controllers = systemTabContentControllers(for: items)
+        let currentControllers = tabBarController.viewControllers ?? []
+        let shouldUpdateControllers = currentControllers.count != controllers.count
+            || zip(currentControllers, controllers).contains { currentController, nextController in
+                currentController !== nextController
+            }
+        let shouldAnimate = animated && tabBarController.viewControllers?.count == controllers.count
+
+        suppressTabSelectEvent = true
+        if shouldUpdateControllers {
+            tabBarController.setViewControllers(controllers, animated: shouldAnimate)
+        }
+        if !controllers.isEmpty {
+            let fallbackIndex = selectedIndex ?? previousSelectedIndex
+            let index = min(max(fallbackIndex, 0), controllers.count - 1)
+            hostWebView(in: controllers[index])
+            tabBarController.selectedIndex = index
+        }
+        suppressTabSelectEvent = false
+
+        tabViewControllers = controllers
+    }
+
+    private func systemTabContentControllers(for items: [UITabBarItem]) -> [UIViewController] {
+        let existingControllers = tabViewControllers.compactMap { $0 as? NativeNavigationTabContentController }
+        if existingControllers.count == items.count {
+            zip(existingControllers, items).forEach { controller, item in
+                controller.tabBarItem = item
+            }
+            return existingControllers
+        }
+
+        return items.map { item -> UIViewController in
             let controller = NativeNavigationTabContentController()
             controller.tabBarItem = item
             return controller
         }
-        let shouldAnimate = animated && tabBarController.viewControllers?.count == controllers.count
-
-        suppressTabSelectEvent = true
-        tabBarController.setViewControllers(controllers, animated: shouldAnimate)
-        if !controllers.isEmpty {
-            let fallbackIndex = selectedIndex ?? previousSelectedIndex
-            let index = min(max(fallbackIndex, 0), controllers.count - 1)
-            tabBarController.selectedIndex = index
-        }
-        hostWebViewInSelectedSystemTab()
-        suppressTabSelectEvent = false
-
-        tabViewControllers = controllers
     }
 
     private func setSystemTabBarHidden(_ hidden: Bool) {
@@ -716,14 +742,18 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
     }
 
     private func hostWebViewInSelectedSystemTab() {
+        hostWebView(in: tabBarController?.selectedViewController)
+    }
+
+    private func hostWebView(in viewController: UIViewController?) {
         guard usesSystemLiquidGlass,
               let webView = webView,
-              let selectedController = tabBarController?.selectedViewController as? NativeNavigationTabContentController else {
+              let selectedController = viewController as? NativeNavigationTabContentController else {
             return
         }
 
         captureOriginalWebViewPlacementIfNeeded(webView)
-        clearHostedWebViews(matching: webView, except: selectedController)
+        clearHostedWebViews(matching: webView, except: selectedController, preservingSnapshots: true)
         guard selectedController.host(webView: webView) else {
             isWebViewHostedInSystemTabController = false
             return
@@ -748,11 +778,15 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         isWebViewHostedInSystemTabController = false
     }
 
-    private func clearHostedWebViews(matching webView: UIView, except owner: NativeNavigationTabContentController? = nil) {
+    private func clearHostedWebViews(
+        matching webView: UIView,
+        except owner: NativeNavigationTabContentController? = nil,
+        preservingSnapshots: Bool = false
+    ) {
         tabViewControllers
             .compactMap { $0 as? NativeNavigationTabContentController }
             .filter { $0 !== owner }
-            .forEach { $0.clearHostedWebView(ifMatching: webView) }
+            .forEach { $0.clearHostedWebView(ifMatching: webView, preservingSnapshot: preservingSnapshots) }
     }
 
     private func makeBarButtonItems(_ rawItems: [[String: Any]], placement: String) -> [UIBarButtonItem] {
@@ -948,12 +982,12 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
 
     private func transitionSnapshotView(from webView: UIView, sourceRect: CGRect?) -> UIView {
         guard let sourceRect = sourceRect else {
-            return webView.snapshotView(afterScreenUpdates: false) ?? UIView(frame: webView.frame)
+            return webView.snapshotView(afterScreenUpdates: false) ?? nativeNavigationSnapshotPlaceholder(for: webView)
         }
 
         let cropRect = sourceRect.intersection(webView.bounds)
         guard cropRect.width > 0, cropRect.height > 0 else {
-            return webView.snapshotView(afterScreenUpdates: false) ?? UIView(frame: webView.frame)
+            return webView.snapshotView(afterScreenUpdates: false) ?? nativeNavigationSnapshotPlaceholder(for: webView)
         }
 
         let renderer = UIGraphicsImageRenderer(bounds: webView.bounds)
@@ -969,7 +1003,7 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         ).integral
 
         guard let croppedImage = image.cgImage?.cropping(to: scaledCropRect) else {
-            return webView.snapshotView(afterScreenUpdates: false) ?? UIView(frame: webView.frame)
+            return webView.snapshotView(afterScreenUpdates: false) ?? nativeNavigationSnapshotPlaceholder(for: webView)
         }
 
         let imageView = UIImageView(image: UIImage(cgImage: croppedImage, scale: scale, orientation: image.imageOrientation))
@@ -1418,19 +1452,20 @@ private final class NativeNavigationBar: UINavigationBar {
 final class NativeNavigationTabController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .clear
-        view.isOpaque = false
+        view.backgroundColor = .systemBackground
+        view.isOpaque = true
         tabBar.isTranslucent = true
     }
 }
 
 final class NativeNavigationTabContentController: UIViewController {
     private weak var hostedWebView: UIView?
+    private var snapshotPlaceholder: UIView?
 
     override func loadView() {
         let view = UIView()
-        view.backgroundColor = .clear
-        view.isOpaque = false
+        view.backgroundColor = .systemBackground
+        view.isOpaque = true
         self.view = view
     }
 
@@ -1443,10 +1478,20 @@ final class NativeNavigationTabContentController: UIViewController {
         hostedWebView?.frame = view.bounds
     }
 
-    func clearHostedWebView(ifMatching webView: UIView? = nil) {
+    func clearHostedWebView(ifMatching webView: UIView? = nil, preservingSnapshot: Bool = false) {
         guard webView == nil || hostedWebView === webView else {
             return
         }
+
+        if preservingSnapshot, let hostedWebView = hostedWebView, hostedWebView.superview === view {
+            let placeholder = hostedWebView.snapshotView(afterScreenUpdates: false) ?? nativeNavigationSnapshotPlaceholder(for: hostedWebView)
+            placeholder.frame = hostedWebView.frame
+            placeholder.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            snapshotPlaceholder?.removeFromSuperview()
+            view.insertSubview(placeholder, belowSubview: hostedWebView)
+            snapshotPlaceholder = placeholder
+        }
+
         hostedWebView = nil
     }
 
@@ -1457,6 +1502,8 @@ final class NativeNavigationTabContentController: UIViewController {
             return false
         }
 
+        snapshotPlaceholder?.removeFromSuperview()
+        snapshotPlaceholder = nil
         hostedWebView = webView
         if webView.superview !== view {
             webView.removeFromSuperview()
@@ -1466,6 +1513,21 @@ final class NativeNavigationTabContentController: UIViewController {
         webView.frame = view.bounds
         return true
     }
+}
+
+private func nativeNavigationFallbackBackground(for view: UIView) -> UIColor {
+    if let color = view.backgroundColor,
+       color.cgColor.alpha > 0 {
+        return color
+    }
+    return .systemBackground
+}
+
+private func nativeNavigationSnapshotPlaceholder(for view: UIView) -> UIView {
+    let placeholder = UIView(frame: view.frame)
+    placeholder.backgroundColor = nativeNavigationFallbackBackground(for: view)
+    placeholder.isOpaque = true
+    return placeholder
 }
 
 private final class SVGIconRenderer: NSObject, XMLParserDelegate {

--- a/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
+++ b/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
@@ -23,6 +23,34 @@ class NativeNavigationTests: XCTestCase {
         XCTAssertEqual(webView.frame, controller.view.bounds)
     }
 
+    func testTabContentControllerKeepsSnapshotPlaceholderWhenWebViewMoves() {
+        let webView = UIView()
+        let firstController = NativeNavigationTabContentController()
+        let secondController = NativeNavigationTabContentController()
+        _ = firstController.view
+        _ = secondController.view
+
+        firstController.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
+        secondController.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
+        webView.backgroundColor = .systemBackground
+
+        XCTAssertTrue(firstController.host(webView: webView))
+        XCTAssertEqual(firstController.view.subviews.count, 1)
+
+        firstController.clearHostedWebView(ifMatching: webView, preservingSnapshot: true)
+        XCTAssertEqual(firstController.view.subviews.count, 2)
+
+        XCTAssertTrue(secondController.host(webView: webView))
+        XCTAssertEqual(webView.superview, secondController.view)
+        XCTAssertEqual(firstController.view.subviews.count, 1)
+        XCTAssertFalse(firstController.view.subviews.contains(webView))
+
+        XCTAssertTrue(firstController.host(webView: webView))
+        XCTAssertEqual(webView.superview, firstController.view)
+        XCTAssertEqual(firstController.view.subviews.count, 1)
+        XCTAssertTrue(firstController.view.subviews.first === webView)
+    }
+
     func testTabContentControllerRejectsLayerCycle() {
         let webView = UIView()
         let controller = NativeNavigationTabContentController()

--- a/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
+++ b/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
@@ -1,19 +1,37 @@
 import XCTest
+import UIKit
 @testable import NativeNavigationPlugin
 
 class NativeNavigationTests: XCTestCase {
-    func testEcho() {
-        let implementation = NativeNavigation()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
-
-        XCTAssertEqual(value, result)
-    }
-
     func testGetPluginVersion() {
         let implementation = NativeNavigation()
         let result = implementation.getPluginVersion()
 
         XCTAssertEqual("native", result)
+    }
+
+    func testTabContentControllerHostsWebView() {
+        let webView = UIView()
+        let originalContainer = UIView()
+        let controller = NativeNavigationTabContentController()
+        _ = controller.view
+
+        originalContainer.addSubview(webView)
+
+        XCTAssertTrue(controller.host(webView: webView))
+        XCTAssertEqual(webView.superview, controller.view)
+        XCTAssertEqual(webView.frame, controller.view.bounds)
+    }
+
+    func testTabContentControllerRejectsLayerCycle() {
+        let webView = UIView()
+        let controller = NativeNavigationTabContentController()
+        _ = controller.view
+
+        webView.addSubview(controller.view)
+
+        XCTAssertFalse(controller.host(webView: webView))
+        XCTAssertNil(webView.superview)
+        XCTAssertEqual(controller.view.superview, webView)
     }
 }


### PR DESCRIPTION
## Summary
- wrap Capacitor's root WKWebView in a clear native container before installing the iOS 26 system tab controller
- keep the system tab controller out of the WebView subtree before moving the WebView into the selected tab content controller
- reject tab hosting attempts that would create a descendant/layer cycle
- remove a stale iOS test that referenced the old echo API and add regression coverage for tab content hosting

## Notes
- Reviewed PR #11 as a starting point, but kept the child controller inside the parent controller's root container instead of inserting it through the WebView superview.

## Verification
- bun run check:wiring
- bun run lint
- bun run verify:ios
- xcodebuild test -scheme CapgoCapacitorNativeNavigation -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1'
- bun run verify

Fixes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS “system liquid glass” tab hosting for improved integration of web content.

* **Bug Fixes**
  * Improved web view hosting stability in system tabs to prevent invalid view hierarchy states and restore prior placements.
  * Better transition snapshot/placeholder handling for smoother tab transitions.

* **Tests**
  * Added tests validating tab hosting, snapshot preservation, and rejection of invalid view cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/12)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->