### PR TITLE
ci: use Node 24 for Capacitor verification

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -29,6 +29,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         id: install_code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         id: install_code
@@ -51,6 +55,10 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - uses: oven-sh/setup-bun@v2
       - name: Install dependencies
         id: install_code

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/Cap-go/capacitor-native-navigation/issues"
   },
   "homepage": "https://capgo.app/docs/plugins/native-navigation/",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "keywords": [
     "capacitor",
     "native-navigation",


### PR DESCRIPTION
## Summary
- fixes the failed release run after #12 by installing Node 24 before Bun/Capacitor verification jobs
- installs Node 24 in the bump-version job before Bun commands as well
- declares the Capacitor 8 Node requirement in package.json so the release workflow is retriggered by a non-ignored file

Failed run: https://github.com/Cap-go/capacitor-native-navigation/actions/runs/25790917991

## Cause
The Android job itself built successfully, but the packed example verification failed when `bunx cap add android` invoked the Capacitor CLI on GitHub Ubuntu with Node < 22. Capacitor CLI now requires NodeJS >= 22.

## Testing
- bun install --frozen-lockfile
- bun run check:wiring
- bun run lint
- bash ./.github/scripts/verify-packed-example.sh android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to configure Node.js v24.x for version bumping and mobile builds.
  * Added Node.js engine requirement (>=22.0.0) to project configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->