### PR TITLE
[codex] Fix tab transition black flash

### DIFF
--- a/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
+++ b/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
@@ -80,6 +80,8 @@ public class NativeNavigationPlugin extends Plugin {
     private String activeTransitionDirection = "forward";
     private RectF activeZoomSourceFrame;
     private float activeZoomCornerRadius = 0f;
+    private Drawable activeTransitionRootBackground;
+    private boolean activeTransitionRootBackgroundCaptured = false;
     private final Map<Integer, String> menuActionIds = new HashMap<>();
     private final Map<Integer, String> menuActionTitles = new HashMap<>();
     private final Map<Integer, String> menuActionPlacements = new HashMap<>();
@@ -290,8 +292,11 @@ public class NativeNavigationPlugin extends Plugin {
 
             if (transitionSnapshot != null) {
                 root.removeView(transitionSnapshot);
+                restoreTransitionRootBackground();
             }
 
+            int transitionSurface = transitionSurfaceColor(webView);
+            prepareTransitionRootBackground(root, transitionSurface);
             Bitmap bitmap = Bitmap.createBitmap(webView.getWidth(), webView.getHeight(), Bitmap.Config.ARGB_8888);
             webView.draw(new Canvas(bitmap));
             if (zoomSourceRect != null) {
@@ -300,6 +305,7 @@ public class NativeNavigationPlugin extends Plugin {
             }
             transitionSnapshot = new ImageView(getContext());
             transitionSnapshot.setImageBitmap(bitmap);
+            transitionSnapshot.setBackgroundColor(transitionSurface);
             transitionSnapshot.setScaleType(ImageView.ScaleType.FIT_XY);
             FrameLayout.LayoutParams params =
                 activeZoomSourceFrame == null
@@ -367,8 +373,9 @@ public class NativeNavigationPlugin extends Plugin {
                 snapshotEndTranslation = -width * 0.3f;
             }
 
+            boolean stationaryTransition = isStationaryTransition(direction);
             webView.setTranslationX(startTranslation);
-            webView.setAlpha("none".equals(direction) ? 1f : 0.01f);
+            webView.setAlpha(stationaryTransition ? 1f : 0.01f);
             View snapshot = transitionSnapshot;
             JSObject event = transitionEvent(transitionId, direction, durationMs);
             Runnable finish = () -> {
@@ -376,6 +383,7 @@ public class NativeNavigationPlugin extends Plugin {
                 if (root != null && transitionSnapshot != null) {
                     root.removeView(transitionSnapshot);
                 }
+                restoreTransitionRootBackground();
                 transitionSnapshot = null;
                 activeTransitionId = null;
                 activeZoomSourceFrame = null;
@@ -395,7 +403,7 @@ public class NativeNavigationPlugin extends Plugin {
                 snapshot
                     .animate()
                     .translationX(snapshotEndTranslation)
-                    .alpha("none".equals(direction) ? 0f : 0.75f)
+                    .alpha(stationaryTransition ? 0f : 0.75f)
                     .setDuration(durationMs)
                     .withEndAction(finish)
                     .start();
@@ -432,6 +440,7 @@ public class NativeNavigationPlugin extends Plugin {
             if (root != null && transitionSnapshot != null) {
                 root.removeView(transitionSnapshot);
             }
+            restoreTransitionRootBackground();
             transitionSnapshot = null;
             activeTransitionId = null;
             activeZoomSourceFrame = null;
@@ -1258,6 +1267,52 @@ public class NativeNavigationPlugin extends Plugin {
         event.put("direction", direction);
         event.put("duration", duration);
         return event;
+    }
+
+    private boolean isStationaryTransition(String direction) {
+        return "tab".equals(direction) || "root".equals(direction) || "none".equals(direction);
+    }
+
+    private void prepareTransitionRootBackground(FrameLayout root, int surfaceColor) {
+        activeTransitionRootBackground = root.getBackground();
+        activeTransitionRootBackgroundCaptured = true;
+        if (needsTransitionSurface(activeTransitionRootBackground)) {
+            root.setBackgroundColor(surfaceColor);
+        }
+    }
+
+    private void restoreTransitionRootBackground() {
+        if (!activeTransitionRootBackgroundCaptured) {
+            return;
+        }
+        FrameLayout root = contentRoot();
+        if (root != null) {
+            root.setBackground(activeTransitionRootBackground);
+        }
+        activeTransitionRootBackground = null;
+        activeTransitionRootBackgroundCaptured = false;
+    }
+
+    private boolean needsTransitionSurface(Drawable background) {
+        if (background == null) {
+            return true;
+        }
+        if (background instanceof ColorDrawable) {
+            return Color.alpha(((ColorDrawable) background).getColor()) < 255;
+        }
+        return false;
+    }
+
+    private int transitionSurfaceColor(View webView) {
+        Drawable background = webView.getBackground();
+        if (background instanceof ColorDrawable) {
+            int color = ((ColorDrawable) background).getColor();
+            if (Color.alpha(color) > 0) {
+                return withAlpha(color, 255);
+            }
+        }
+        int fallback = isNightMode() ? Color.rgb(18, 18, 18) : Color.WHITE;
+        return dynamicColor(isNightMode() ? "system_neutral1_900" : "system_neutral1_50", fallback);
     }
 
     private FrameLayout contentRoot() {

--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -70,6 +70,10 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
     private var activeTransitionDirection = "forward"
     private var activeZoomSourceFrame: CGRect?
     private var activeZoomCornerRadius: CGFloat = 0
+    private weak var activeTransitionContainer: UIView?
+    private var activeTransitionContainerBackgroundColor: UIColor?
+    private var activeTransitionContainerWasOpaque = false
+    private var activeTransitionContainerBackgroundCaptured = false
 
     private var usesSystemLiquidGlass: Bool {
         if #available(iOS 26.0, *) {
@@ -232,9 +236,14 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
             let cornerRadius = CGFloat(call.getDouble("cornerRadius") ?? 0)
 
             self.transitionSnapshot?.removeFromSuperview()
+            self.restoreTransitionContainerBackground()
+            let transitionSurface = nativeNavigationFallbackBackground(for: webView)
+            self.prepareTransitionContainerBackground(transitionContainer, surface: transitionSurface)
             let snapshot = self.transitionSnapshotView(from: webView, sourceRect: zoomSourceRect)
             snapshot.frame = zoomSourceFrame ?? webView.frame
             snapshot.autoresizingMask = zoomSourceFrame == nil ? [.flexibleWidth, .flexibleHeight] : []
+            snapshot.backgroundColor = transitionSurface
+            snapshot.isOpaque = true
             snapshot.layer.cornerRadius = cornerRadius
             snapshot.clipsToBounds = cornerRadius > 0
             transitionContainer.insertSubview(snapshot, aboveSubview: webView)
@@ -292,8 +301,9 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
     private func finishStandardTransition(_ transition: NativeNavigationTransitionContext) {
         let width = transition.webView.bounds.width
         let transforms = standardTransitionTransforms(direction: transition.direction, width: width)
+        let usesStationaryCrossfade = nativeNavigationUsesStationaryTransitionCrossfade(direction: transition.direction)
         transition.webView.transform = transforms.start
-        transition.webView.alpha = transition.direction == "none" ? 1 : 0.01
+        transition.webView.alpha = usesStationaryCrossfade ? 1 : 0.01
 
         UIView.animate(
             withDuration: max(transition.duration, 0),
@@ -303,7 +313,7 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
                 transition.webView.transform = .identity
                 transition.webView.alpha = 1
                 transition.snapshot?.transform = transforms.snapshotEnd
-                transition.snapshot?.alpha = transition.direction == "none" ? 0 : 0.75
+                transition.snapshot?.alpha = usesStationaryCrossfade ? 0 : 0.75
             },
             completion: { _ in
                 self.finishTransitionCleanup(transition)
@@ -407,11 +417,35 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
         transition.webView.layer.cornerRadius = 0
         transition.webView.clipsToBounds = false
         transitionSnapshot = nil
+        restoreTransitionContainerBackground()
         activeTransitionId = nil
         activeZoomSourceFrame = nil
         let event: [String: Any] = ["id": transition.id, "direction": transition.direction, "duration": transition.durationMs]
         notifyListeners("transitionEnd", data: event)
         transition.resolve(event)
+    }
+
+    private func prepareTransitionContainerBackground(_ container: UIView, surface: UIColor) {
+        activeTransitionContainer = container
+        activeTransitionContainerBackgroundColor = container.backgroundColor
+        activeTransitionContainerWasOpaque = container.isOpaque
+        activeTransitionContainerBackgroundCaptured = true
+        if nativeNavigationNeedsTransitionSurface(container.backgroundColor) {
+            container.backgroundColor = surface
+            container.isOpaque = true
+        }
+    }
+
+    private func restoreTransitionContainerBackground() {
+        guard activeTransitionContainerBackgroundCaptured else {
+            return
+        }
+        activeTransitionContainer?.backgroundColor = activeTransitionContainerBackgroundColor
+        activeTransitionContainer?.isOpaque = activeTransitionContainerWasOpaque
+        activeTransitionContainer = nil
+        activeTransitionContainerBackgroundColor = nil
+        activeTransitionContainerWasOpaque = false
+        activeTransitionContainerBackgroundCaptured = false
     }
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {
@@ -1614,6 +1648,17 @@ private func nativeNavigationFallbackBackground(for view: UIView) -> UIColor {
         return color
     }
     return .systemBackground
+}
+
+func nativeNavigationUsesStationaryTransitionCrossfade(direction: String) -> Bool {
+    direction == "tab" || direction == "root" || direction == "none"
+}
+
+private func nativeNavigationNeedsTransitionSurface(_ color: UIColor?) -> Bool {
+    guard let color else {
+        return true
+    }
+    return color.cgColor.alpha < 1
 }
 
 private func nativeNavigationSnapshotPlaceholder(for view: UIView) -> UIView {

--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -237,7 +237,7 @@ public class NativeNavigationPlugin: CAPPlugin, CAPBridgedPlugin, UITabBarContro
 
             self.transitionSnapshot?.removeFromSuperview()
             self.restoreTransitionContainerBackground()
-            let transitionSurface = nativeNavigationFallbackBackground(for: webView)
+            let transitionSurface = nativeNavigationFallbackBackground(for: webView).withAlphaComponent(1.0)
             self.prepareTransitionContainerBackground(transitionContainer, surface: transitionSurface)
             let snapshot = self.transitionSnapshotView(from: webView, sourceRect: zoomSourceRect)
             snapshot.frame = zoomSourceFrame ?? webView.frame
@@ -1647,7 +1647,7 @@ private func nativeNavigationFallbackBackground(for view: UIView) -> UIColor {
        color.cgColor.alpha > 0 {
         return color.withAlphaComponent(1)
     }
-    return .systemBackground
+    return UIColor.systemBackground.withAlphaComponent(1.0)
 }
 
 func nativeNavigationUsesStationaryTransitionCrossfade(direction: String) -> Bool {

--- a/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
+++ b/ios/Sources/NativeNavigationPlugin/NativeNavigationPlugin.swift
@@ -1645,7 +1645,7 @@ final class NativeNavigationTabContentController: UIViewController {
 private func nativeNavigationFallbackBackground(for view: UIView) -> UIColor {
     if let color = view.backgroundColor,
        color.cgColor.alpha > 0 {
-        return color
+        return color.withAlphaComponent(1)
     }
     return .systemBackground
 }

--- a/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
+++ b/ios/Tests/NativeNavigationPluginTests/NativeNavigationTests.swift
@@ -89,4 +89,12 @@ class NativeNavigationTests: XCTestCase {
         XCTAssertNil(webView.superview)
         XCTAssertEqual(controller.view.superview, webView)
     }
+
+    func testStationaryTransitionsCrossfadeSnapshotsAway() {
+        XCTAssertTrue(nativeNavigationUsesStationaryTransitionCrossfade(direction: "tab"))
+        XCTAssertTrue(nativeNavigationUsesStationaryTransitionCrossfade(direction: "root"))
+        XCTAssertTrue(nativeNavigationUsesStationaryTransitionCrossfade(direction: "none"))
+        XCTAssertFalse(nativeNavigationUsesStationaryTransitionCrossfade(direction: "forward"))
+        XCTAssertFalse(nativeNavigationUsesStationaryTransitionCrossfade(direction: "back"))
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #13 by keeping tab/root transitions on a stable, opaque transition surface instead of briefly exposing an empty black frame behind the native tab bar.

## Root cause

The transition flow hides the WebView while a captured snapshot is displayed. For stationary tab/root transitions, the old snapshot stayed semi-opaque and the underlying transition container could be transparent, so the bottom bar blur/transparency could sample a black backing layer before the incoming tab content was fully visible.

## Changes

- Add a temporary opaque transition surface on Android and iOS, restored after transition cleanup.
- Keep stationary `tab`, `root`, and `none` transitions from dimming the live WebView.
- Fade the captured snapshot away for stationary transitions instead of leaving it at 75% opacity.
- Add a Swift unit guard for the stationary transition classification.

## Validation

- `npx tsc --noEmit`
- `npx eslint . --ext .ts`
- `npx prettier --check "android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java" --plugin=prettier-plugin-java`
- `npm run check:wiring`
- `npx tsc`
- `npx rollup -c rollup.config.mjs`
- `git diff --check`

Notes: full `bun run verify`, Android Gradle, and iOS Xcode verification could not run in this Windows environment because Bun, Java/JAVA_HOME, and Xcode are unavailable. `npx swiftlint` exits successfully here but reports that SwiftLint is skipped on non-macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transition visuals by capturing/restoring container background colors and applying a normalized transition surface so crossfades remain visually consistent across platforms and transition types.
  * Expanded stationary-crossfade behavior to additional transition directions for smoother alpha handling.

* **Tests**
  * Added a unit test verifying stationary-crossfade behavior for relevant transition directions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/18)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->