### PR TITLE
fix: align iOS package names with Capacitor

### DIFF
--- a/CapgoCapacitorNativeNavigation.podspec
+++ b/CapgoCapacitorNativeNavigation.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapgoNativeNavigation'
+  s.name = 'CapgoCapacitorNativeNavigation'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapgoNativeNavigation",
+    name: "CapgoCapacitorNativeNavigation",
     platforms: [.iOS(.v15)],
     products: [
         .library(
-            name: "CapgoNativeNavigation",
+            name: "CapgoCapacitorNativeNavigation",
             targets: ["NativeNavigationPlugin"])
     ],
     dependencies: [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapgoNativeNavigation.podspec"
+    "CapgoCapacitorNativeNavigation.podspec"
   ],
   "author": "Martin Donadieu <martin@capgo.app>",
   "license": "MPL-2.0",
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoNativeNavigation -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorNativeNavigation -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "bun run build",
     "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -9,6 +9,7 @@
  *
  * And (when iOS is declared in package.json capacitor config):
  * - CocoaPods podspec s.name matches SwiftPM Package(name: ...) and .library(name: ...)
+ * - iOS package/spec names match Capacitor's normalized npm package name
  *
  * Usage:
  *   node scripts/check-capacitor-plugin-wiring.mjs            # checks current working dir
@@ -86,6 +87,20 @@ function uniq(arr) {
   return out;
 }
 
+function upperFirst(s) {
+  return s ? `${s[0].toUpperCase()}${s.slice(1)}` : "";
+}
+
+function packageNameToCapacitorIosName(packageName) {
+  return packageName
+    .replace(/^@/, "")
+    .split("/")
+    .flatMap((part) => part.split(/[^A-Za-z0-9]+/))
+    .filter(Boolean)
+    .map((part) => upperFirst(part))
+    .join("");
+}
+
 function parseArgs(argv) {
   const out = { dir: process.cwd() };
   for (let i = 2; i < argv.length; i++) {
@@ -118,6 +133,7 @@ try {
 const cap = typeof pkg.capacitor === "object" && pkg.capacitor ? pkg.capacitor : {};
 const supportsAndroid = typeof cap.android === "object" && cap.android;
 const supportsIos = typeof cap.ios === "object" && cap.ios;
+const expectedIosName = packageNameToCapacitorIosName(pkg.name || "");
 
 // Not a Capacitor plugin package (e.g. meta/workspace package).
 // We only enforce wiring rules for actual plugin packages declaring a `capacitor` config.
@@ -233,8 +249,18 @@ if (supportsIos) {
   } else if (podspecs.length) {
     const podName = parsePodspecName(podspecs[0]);
     const { pkgName, libNames } = parseSpmNames(pkgSwift);
+    const podspecFileName = path.basename(podspecs[0], ".podspec");
     if (!podName) errors.push("Podspec: missing s.name = '...'");
     if (!pkgName) errors.push('SPM: missing Package(name: "...")');
+    if (expectedIosName && podspecFileName !== expectedIosName) {
+      errors.push(`Podspec: filename=${podspecFileName}.podspec != Capacitor iOS package name ${expectedIosName}`);
+    }
+    if (expectedIosName && podName && podName !== expectedIosName) {
+      errors.push(`Podspec: s.name=${podName} != Capacitor iOS package name ${expectedIosName}`);
+    }
+    if (expectedIosName && pkgName && pkgName !== expectedIosName) {
+      errors.push(`SPM: Package(name)=${pkgName} != Capacitor iOS package name ${expectedIosName}`);
+    }
     if (podName && pkgName && podName !== pkgName) {
       errors.push(`Podspec: s.name=${podName} != Package(name)=${pkgName}`);
     }

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -31,6 +31,12 @@ const SKIP_DIRS = new Set([
   ".git",
 ]);
 
+/**
+ * Reads a UTF-8 text file, returning an empty string when it is unavailable.
+ *
+ * @param {string} p - Absolute or relative file path.
+ * @returns {string} File contents, or an empty string when reading fails.
+ */
 function readText(p) {
   try {
     return fs.readFileSync(p, "utf8");
@@ -39,6 +45,12 @@ function readText(p) {
   }
 }
 
+/**
+ * Checks whether a filesystem path is accessible.
+ *
+ * @param {string} p - Absolute or relative filesystem path.
+ * @returns {boolean} True when the path exists and can be accessed.
+ */
 function exists(p) {
   try {
     fs.accessSync(p);
@@ -48,6 +60,13 @@ function exists(p) {
   }
 }
 
+/**
+ * Recursively lists files under a root directory that match any extension.
+ *
+ * @param {string} rootDir - Directory to scan.
+ * @param {string[]} exts - File extensions to include, such as ".ts".
+ * @returns {string[]} Sorted absolute or joined file paths.
+ */
 function walkFiles(rootDir, exts) {
   const out = [];
   const stack = [rootDir];
@@ -78,6 +97,12 @@ function walkFiles(rootDir, exts) {
   return out;
 }
 
+/**
+ * Returns unique truthy values while preserving first-seen order.
+ *
+ * @param {string[]} arr - Values to deduplicate.
+ * @returns {string[]} Unique non-empty values.
+ */
 function uniq(arr) {
   const out = [];
   for (const x of arr) {
@@ -87,10 +112,22 @@ function uniq(arr) {
   return out;
 }
 
+/**
+ * Uppercases the first character of a string.
+ *
+ * @param {string} s - Input string.
+ * @returns {string} Input string with its first character uppercased.
+ */
 function upperFirst(s) {
   return s ? `${s[0].toUpperCase()}${s.slice(1)}` : "";
 }
 
+/**
+ * Converts an npm package name into Capacitor's normalized iOS package name.
+ *
+ * @param {string} packageName - npm package name, optionally scoped.
+ * @returns {string} PascalCase iOS package name expected by Capacitor.
+ */
 function packageNameToCapacitorIosName(packageName) {
   return packageName
     .replace(/^@/, "")
@@ -101,6 +138,12 @@ function packageNameToCapacitorIosName(packageName) {
     .join("");
 }
 
+/**
+ * Parses command-line arguments for the plugin directory to inspect.
+ *
+ * @param {string[]} argv - Process argument vector.
+ * @returns {{ dir: string }} Parsed options.
+ */
 function parseArgs(argv) {
   const out = { dir: process.cwd() };
   for (let i = 2; i < argv.length; i++) {
@@ -199,12 +242,24 @@ if (supportsIos) {
 }
 
 // ---------------- Podspec/SPM ----------------
+/**
+ * Extracts the CocoaPods spec name from a podspec file.
+ *
+ * @param {string} podspecPath - Path to a podspec file.
+ * @returns {string} Podspec name, or an empty string when absent.
+ */
 function parsePodspecName(podspecPath) {
   const txt = readText(podspecPath);
   const m = /\bs\.name\s*=\s*'([^']+)'/.exec(txt);
   return m ? m[1] : "";
 }
 
+/**
+ * Extracts Swift Package Manager package and library product names.
+ *
+ * @param {string} packageSwiftPath - Path to Package.swift.
+ * @returns {{ pkgName: string, libNames: string[] }} Package name and library names.
+ */
 function parseSpmNames(packageSwiftPath) {
   const txt = readText(packageSwiftPath);
   const pkg = /Package\(\s*name\s*:\s*"([^"]+)"/.exec(txt)?.[1] || "";


### PR DESCRIPTION
## Summary
- rename the SwiftPM package/product to `CapgoCapacitorNativeNavigation`, matching Capacitor's normalized iOS name for `@capgo/capacitor-native-navigation`
- rename the CocoaPods spec and published package file entry to the same iOS name
- extend the wiring checker to validate podspec/SPM names against the normalized npm package name
- add JSDoc for wiring checker helpers so CodeRabbit docstring coverage passes

Fixes #7.

## Checks
- `bun run check:wiring`
- `bun run eslint`
- `bun run prettier -- --check`
- `git diff --check`

## Not run
- `bun run verify:ios` requires `xcodebuild`, which is not available in this Linux environment
- `bun run verify:android` is blocked here by Java 8; Android Gradle plugin 8.13.0 requires Java 11+


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized iOS package naming across CocoaPods and Swift Package Manager configurations for improved consistency.
  * Enhanced validation tooling to verify naming consistency across iOS packaging metadata and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/19)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->