### PR TITLE
[codex] Add Capgo example app deployment

### DIFF
--- a/.github/workflows/deploy_example_app.yml
+++ b/.github/workflows/deploy_example_app.yml
@@ -1,0 +1,108 @@
+name: Deploy example app to Capgo
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Capgo channel'
+        required: false
+        default: 'production'
+      bundle:
+        description: 'Optional bundle version'
+        required: false
+      comment:
+        description: 'Optional release comment'
+        required: false
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'ios/**'
+      - 'android/**'
+      - 'example-app/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'rollup.config.mjs'
+      - 'tsconfig.json'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install plugin dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build plugin
+        run: bun run build
+
+      - name: Install example dependencies
+        working-directory: example-app
+        run: bun install --frozen-lockfile
+
+      - name: Build example app
+        working-directory: example-app
+        run: bun run build
+
+      - name: Resolve Capgo upload metadata
+        id: upload
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          channel="${{ github.event.inputs.channel }}"
+          bundle="${{ github.event.inputs.bundle }}"
+          comment="${{ github.event.inputs.comment }}"
+
+          if [[ -z "$channel" ]]; then
+            channel="production"
+          fi
+
+          if [[ -z "$bundle" ]]; then
+            safe_channel="$(printf '%s' "$channel" | tr -c '0-9A-Za-z-' '-')"
+            bundle="0.0.1-${safe_channel}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          fi
+
+          if [[ -z "$comment" ]]; then
+            comment="Native navigation example ${GITHUB_SHA}"
+          fi
+
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "bundle=$bundle" >> "$GITHUB_OUTPUT"
+          echo "comment=$comment" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Capgo
+        working-directory: example-app
+        run: |
+          bunx @capgo/cli@latest bundle upload app.capgo.capacitor.navigation \
+            --path dist \
+            --channel "${{ steps.upload.outputs.channel }}" \
+            --bundle "${{ steps.upload.outputs.bundle }}" \
+            --package-json package.json \
+            --node-modules node_modules \
+            --delta \
+            --no-key \
+            --ignore-checksum-check \
+            --version-exists-ok \
+            --comment "${{ steps.upload.outputs.comment }}"
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.capgo_key*
 
 
 # macOS files

--- a/example-app/.gitignore
+++ b/example-app/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vscode/
 *.map
 .sourcemaps
+.capgo_key*

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -4,15 +4,40 @@ This Vite project links directly to the local plugin source so you can validate 
 
 ## Getting started
 
+From the repository root:
+
 ```bash
 bun install
+bun run example:build
+cd example-app
 bun run start
 ```
 
 To test on native shells:
 
 ```bash
-bunx cap add ios
-bunx cap add android
-bunx cap sync
+bun run cap:sync
+bun run cap:ios
+bun run cap:android
 ```
+
+The iOS and Android commands add the native platform folder the first time they run.
+
+## Capgo Cloud testing
+
+This app is configured for Capgo Cloud with app id `app.capgo.capacitor.navigation` and the `production` channel.
+
+First-time setup in Capgo:
+
+```bash
+bunx @capgo/cli@latest app add app.capgo.capacitor.navigation --name "Native Navigation Example"
+bunx @capgo/cli@latest channel add production app.capgo.capacitor.navigation --default --self-assign
+```
+
+Deploy a new OTA bundle:
+
+```bash
+bun run capgo:deploy
+```
+
+Use `CAPGO_CHANNEL`, `CAPGO_BUNDLE_VERSION`, or `CAPGO_APP_ID` when you need to override the defaults.

--- a/example-app/bun.lock
+++ b/example-app/bun.lock
@@ -9,6 +9,7 @@
         "@capacitor/core": "^8.0.0",
         "@capacitor/ios": "^8.0.0",
         "@capgo/capacitor-native-navigation": "file:..",
+        "@capgo/capacitor-updater": "^8.45.11",
       },
       "devDependencies": {
         "@capacitor/cli": "^8.0.0",
@@ -32,6 +33,8 @@
     "@capacitor/ios": ["@capacitor/ios@8.1.0", "", { "peerDependencies": { "@capacitor/core": "^8.1.0" } }, "sha512-wPaQ8ayL0UY+SxydZbrmfzPs8TryZVEB6hrL/XBnXxQtb6rpEmIy/3GIltPwM+/T4m/IuaSDZOToWK65ruC00g=="],
 
     "@capgo/capacitor-native-navigation": ["@capgo/capacitor-native-navigation@file:..", { "devDependencies": { "@capacitor/android": "^8.0.0", "@capacitor/cli": "^8.0.0", "@capacitor/core": "^8.0.0", "@capacitor/docgen": "^0.3.1", "@capacitor/ios": "^8.0.0", "@ionic/eslint-config": "^0.4.0", "@ionic/prettier-config": "^4.0.0", "@ionic/swiftlint-config": "^2.0.0", "@types/node": "^24.10.1", "eslint": "^8.57.1", "eslint-plugin-import": "^2.31.0", "husky": "^9.1.7", "prettier": "^3.6.2", "prettier-plugin-java": "^2.7.7", "prettier-pretty-check": "^0.2.0", "rimraf": "^6.1.0", "rollup": "^4.53.2", "swiftlint": "^2.0.0", "typescript": "^5.9.3" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }],
+
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.46.1", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-wWPkfbPBZmo9Jv/7zbUsnBDN8qi4MkuFNdGoSbbkpYr2pXY0EWDhlsYbLl/+DpfU3IaZsIealuxFW7gpjcMr2g=="],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.0.3", "", { "dependencies": { "@chevrotain/gast": "11.0.3", "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ=="],
 

--- a/example-app/capacitor.config.json
+++ b/example-app/capacitor.config.json
@@ -1,5 +1,18 @@
 {
-  "appId": "app.capgo.nativenavigation.example",
+  "appId": "app.capgo.capacitor.navigation",
   "appName": "Native Navigation Example",
-  "webDir": "dist"
+  "webDir": "dist",
+  "plugins": {
+    "CapacitorUpdater": {
+      "appId": "app.capgo.capacitor.navigation",
+      "autoUpdate": true,
+      "autoSplashscreen": true,
+      "directUpdate": "always",
+      "defaultChannel": "production",
+      "version": "0.0.0"
+    }
+  },
+  "android": {
+    "webContentsDebuggingEnabled": true
+  }
 }

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -6,12 +6,17 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "cap:sync": "cd .. && bun run example:sync",
+    "cap:ios": "cd .. && bun run example:ios",
+    "cap:android": "cd .. && bun run example:android",
+    "capgo:deploy": "cd .. && bun run example:capgo:deploy"
   },
   "dependencies": {
     "@capacitor/core": "^8.0.0",
     "@capacitor/android": "^8.0.0",
     "@capacitor/ios": "^8.0.0",
+    "@capgo/capacitor-updater": "^8.45.11",
     "@capgo/capacitor-native-navigation": "file:.."
   },
   "devDependencies": {

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -1,7 +1,12 @@
 import './style.css';
+import { CapacitorUpdater } from '@capgo/capacitor-updater';
 import { NativeNavigation } from '@capgo/capacitor-native-navigation';
 
 const app = document.getElementById('app');
+
+void CapacitorUpdater.notifyAppReady().catch((error) => {
+  console.warn('Capgo updater notifyAppReady failed', error);
+});
 
 const icons = {
   home: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>',

--- a/example-app/vite.config.ts
+++ b/example-app/vite.config.ts
@@ -1,6 +1,19 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const localPluginEntry = resolve(currentDir, '../dist/esm/index.js');
+
 export default defineConfig({
+  resolve: {
+    alias: existsSync(localPluginEntry)
+      ? {
+          '@capgo/capacitor-native-navigation': localPluginEntry,
+        }
+      : {},
+  },
   server: {
     open: true,
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,12 @@
     "watch": "tsc --watch",
     "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs",
-    "demo:readme": "bun scripts/generate-readme-demos.mjs"
+    "demo:readme": "bun scripts/generate-readme-demos.mjs",
+    "example:build": "bun run build && cd example-app && bun install && bun run build",
+    "example:capgo:deploy": "bun run example:build && bun scripts/deploy-example-capgo.mjs",
+    "example:sync": "bun run example:build && cd example-app && bunx cap sync",
+    "example:ios": "bun run example:build && cd example-app && ([ -d ios ] || bunx cap add ios) && bunx cap sync ios && bunx cap run ios",
+    "example:android": "bun run example:build && cd example-app && ([ -d android ] || bunx cap add android) && bunx cap sync android && bunx cap run android"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/scripts/deploy-example-capgo.mjs
+++ b/scripts/deploy-example-capgo.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const appDir = resolve(repoRoot, 'example-app');
+const distDir = resolve(appDir, 'dist');
+
+const appId = process.env.CAPGO_APP_ID || 'app.capgo.capacitor.navigation';
+const channel = process.env.CAPGO_CHANNEL || process.argv[2] || 'production';
+const safeChannel = channel.replace(/[^0-9A-Za-z-]/g, '-');
+const bundle = process.env.CAPGO_BUNDLE_VERSION || `0.0.1-${safeChannel}.${Date.now()}`;
+const comment =
+  process.env.CAPGO_COMMENT ||
+  (process.env.GITHUB_SHA ? `Native navigation example ${process.env.GITHUB_SHA}` : 'Native navigation example upload');
+
+if (!existsSync(distDir)) {
+  console.error('Missing example-app/dist. Run bun run --cwd example-app build first.');
+  process.exit(1);
+}
+
+const args = [
+  '@capgo/cli@latest',
+  'bundle',
+  'upload',
+  appId,
+  '--path',
+  'dist',
+  '--channel',
+  channel,
+  '--bundle',
+  bundle,
+  '--package-json',
+  'package.json',
+  '--node-modules',
+  'node_modules',
+  '--delta',
+  '--no-key',
+  '--ignore-checksum-check',
+  '--version-exists-ok',
+  '--comment',
+  comment,
+];
+
+console.log(`Deploying ${appId}@${bundle} to Capgo channel "${channel}"`);
+
+const result = spawnSync('bunx', args, {
+  cwd: appDir,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- Configure the example app for Capgo Cloud with app id `app.capgo.capacitor.navigation` and the Capgo updater plugin.
- Add root and example-app helper scripts for building, syncing, running mobile shells, and uploading an OTA bundle to Capgo.
- Add a GitHub Actions workflow that builds the example app and deploys its bundle to Capgo when relevant changes land on `main` or when run manually.

## Testing

- `bun run example:build`
- `bun run --cwd example-app cap:sync`
- `bun run check:wiring`
- `bunx prettier --check .github/workflows/deploy_example_app.yml scripts/deploy-example-capgo.mjs example-app/README.md example-app/capacitor.config.json example-app/package.json package.json example-app/src/main.js example-app/vite.config.ts`
- `bun run lint`
- `bun run verify:web`
- `bun run verify` (iOS passed; Android stopped locally because no Java runtime is installed)

Capgo upload was not run locally because it publishes a bundle and requires `CAPGO_TOKEN`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment pipeline for example app to Capgo
  * Integrated Capgo Cloud support for example app testing

* **Documentation**
  * Updated example app README with Capgo Cloud setup and deployment instructions, including environment variable configuration

* **Chores**
  * Added example app build and deployment scripts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-navigation/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->