### PR TITLE
[codex] Align Capgo example upload version

### DIFF
--- a/.github/workflows/deploy_example_app.yml
+++ b/.github/workflows/deploy_example_app.yml
@@ -11,9 +11,6 @@ on:
         description: 'Capgo channel'
         required: false
         default: 'production'
-      bundle:
-        description: 'Optional bundle version'
-        required: false
       comment:
         description: 'Optional release comment'
         required: false
@@ -70,17 +67,25 @@ jobs:
           set -euo pipefail
 
           channel="${{ github.event.inputs.channel }}"
-          bundle="${{ github.event.inputs.bundle }}"
           comment="${{ github.event.inputs.comment }}"
+          package_version="$(bun -e "const pkg = require('./example-app/package.json'); console.log(pkg.version)")"
+          config_version="$(bun -e "const cfg = require('./example-app/capacitor.config.json'); console.log(cfg.plugins?.CapacitorUpdater?.version ?? '')")"
 
           if [[ -z "$channel" ]]; then
             channel="production"
           fi
 
-          if [[ -z "$bundle" ]]; then
-            safe_channel="$(printf '%s' "$channel" | tr -c '0-9A-Za-z-' '-')"
-            bundle="0.0.1-${safe_channel}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          if [[ -z "$package_version" ]]; then
+            echo "example-app/package.json is missing a version."
+            exit 1
           fi
+
+          if [[ "$config_version" != "$package_version" ]]; then
+            echo "CapacitorUpdater.version ($config_version) must match example-app/package.json version ($package_version)."
+            exit 1
+          fi
+
+          bundle="$package_version"
 
           if [[ -z "$comment" ]]; then
             comment="Native navigation example ${GITHUB_SHA}"

--- a/.github/workflows/deploy_example_app.yml
+++ b/.github/workflows/deploy_example_app.yml
@@ -68,7 +68,7 @@ jobs:
 
           channel="${{ github.event.inputs.channel }}"
           comment="${{ github.event.inputs.comment }}"
-          package_version="$(bun -e "const pkg = require('./example-app/package.json'); console.log(pkg.version)")"
+          package_version="$(bun -e "const pkg = require('./package.json'); console.log(pkg.version)")"
           config_version="$(bun -e "const cfg = require('./example-app/capacitor.config.json'); console.log(cfg.plugins?.CapacitorUpdater?.version ?? '')")"
 
           if [[ -z "$channel" ]]; then
@@ -76,12 +76,12 @@ jobs:
           fi
 
           if [[ -z "$package_version" ]]; then
-            echo "example-app/package.json is missing a version."
+            echo "package.json is missing a version."
             exit 1
           fi
 
           if [[ "$config_version" != "$package_version" ]]; then
-            echo "CapacitorUpdater.version ($config_version) must match example-app/package.json version ($package_version)."
+            echo "CapacitorUpdater.version ($config_version) must match package.json version ($package_version)."
             exit 1
           fi
 
@@ -102,8 +102,8 @@ jobs:
             --path dist \
             --channel "${{ steps.upload.outputs.channel }}" \
             --bundle "${{ steps.upload.outputs.bundle }}" \
-            --package-json package.json \
-            --node-modules node_modules \
+            --package-json ../package.json,package.json \
+            --node-modules ../node_modules,node_modules \
             --delta \
             --no-key \
             --ignore-checksum-check \

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -40,4 +40,4 @@ Deploy a new OTA bundle:
 bun run capgo:deploy
 ```
 
-Use `CAPGO_CHANNEL`, `CAPGO_BUNDLE_VERSION`, or `CAPGO_APP_ID` when you need to override the defaults.
+The Capgo bundle version is read from `example-app/package.json` and must match `plugins.CapacitorUpdater.version` in `capacitor.config.json`. Use `CAPGO_CHANNEL` or `CAPGO_APP_ID` when you need to override the deployment target.

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -40,4 +40,4 @@ Deploy a new OTA bundle:
 bun run capgo:deploy
 ```
 
-The Capgo bundle version is read from `example-app/package.json` and must match `plugins.CapacitorUpdater.version` in `capacitor.config.json`. Use `CAPGO_CHANNEL` or `CAPGO_APP_ID` when you need to override the deployment target.
+The Capgo bundle version is read from the root plugin `package.json` and must match `plugins.CapacitorUpdater.version` in `capacitor.config.json`. Use `CAPGO_CHANNEL` or `CAPGO_APP_ID` when you need to override the deployment target.

--- a/example-app/capacitor.config.json
+++ b/example-app/capacitor.config.json
@@ -9,7 +9,7 @@
       "autoSplashscreen": true,
       "directUpdate": "always",
       "defaultChannel": "production",
-      "version": "0.0.0"
+      "version": "1.0.0"
     }
   },
   "android": {

--- a/example-app/capacitor.config.json
+++ b/example-app/capacitor.config.json
@@ -9,7 +9,7 @@
       "autoSplashscreen": true,
       "directUpdate": "always",
       "defaultChannel": "production",
-      "version": "1.0.0"
+      "version": "8.0.19"
     }
   },
   "android": {

--- a/scripts/deploy-example-capgo.mjs
+++ b/scripts/deploy-example-capgo.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,14 +8,31 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
 const appDir = resolve(repoRoot, 'example-app');
 const distDir = resolve(appDir, 'dist');
+const packageJsonPath = resolve(appDir, 'package.json');
+const capacitorConfigPath = resolve(appDir, 'capacitor.config.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const capacitorConfig = JSON.parse(readFileSync(capacitorConfigPath, 'utf8'));
+const packageVersion = packageJson.version;
+const configVersion = capacitorConfig.plugins?.CapacitorUpdater?.version;
 
 const appId = process.env.CAPGO_APP_ID || 'app.capgo.capacitor.navigation';
 const channel = process.env.CAPGO_CHANNEL || process.argv[2] || 'production';
-const safeChannel = channel.replace(/[^0-9A-Za-z-]/g, '-');
-const bundle = process.env.CAPGO_BUNDLE_VERSION || `0.0.1-${safeChannel}.${Date.now()}`;
+const bundle = packageVersion;
 const comment =
   process.env.CAPGO_COMMENT ||
   (process.env.GITHUB_SHA ? `Native navigation example ${process.env.GITHUB_SHA}` : 'Native navigation example upload');
+
+if (!packageVersion) {
+  console.error('Missing example-app/package.json version.');
+  process.exit(1);
+}
+
+if (configVersion !== packageVersion) {
+  console.error(
+    `CapacitorUpdater.version (${configVersion ?? 'missing'}) must match example-app/package.json version (${packageVersion}).`,
+  );
+  process.exit(1);
+}
 
 if (!existsSync(distDir)) {
   console.error('Missing example-app/dist. Run bun run --cwd example-app build first.');

--- a/scripts/deploy-example-capgo.mjs
+++ b/scripts/deploy-example-capgo.mjs
@@ -8,7 +8,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
 const appDir = resolve(repoRoot, 'example-app');
 const distDir = resolve(appDir, 'dist');
-const packageJsonPath = resolve(appDir, 'package.json');
+const packageJsonPath = resolve(repoRoot, 'package.json');
 const capacitorConfigPath = resolve(appDir, 'capacitor.config.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 const capacitorConfig = JSON.parse(readFileSync(capacitorConfigPath, 'utf8'));
@@ -23,13 +23,13 @@ const comment =
   (process.env.GITHUB_SHA ? `Native navigation example ${process.env.GITHUB_SHA}` : 'Native navigation example upload');
 
 if (!packageVersion) {
-  console.error('Missing example-app/package.json version.');
+  console.error('Missing package.json version.');
   process.exit(1);
 }
 
 if (configVersion !== packageVersion) {
   console.error(
-    `CapacitorUpdater.version (${configVersion ?? 'missing'}) must match example-app/package.json version (${packageVersion}).`,
+    `CapacitorUpdater.version (${configVersion ?? 'missing'}) must match package.json version (${packageVersion}).`,
   );
   process.exit(1);
 }
@@ -51,9 +51,9 @@ const args = [
   '--bundle',
   bundle,
   '--package-json',
-  'package.json',
+  '../package.json,package.json',
   '--node-modules',
-  'node_modules',
+  '../node_modules,node_modules',
   '--delta',
   '--no-key',
   '--ignore-checksum-check',


### PR DESCRIPTION
## Summary

- add the Capgo example-app deployment workflow and helper script
- align Capgo bundle uploads with the root plugin package version from package.json
- fail deploys when CapacitorUpdater.version drifts from the root plugin package version

## Root cause

The upload path was not using the library package version as the Capgo bundle version. It first generated a synthetic 0.0.1 build string, then was corrected to the example app package version. This now uses the root @capgo/capacitor-native-navigation package version instead.

## Validation

- bun run lint
- bun run example:build
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:$HOME/Library/Android/sdk/platform-tools:$PATH bun run verify