### PR TITLE
fix: stabilize Android tab bar layout

### DIFF
--- a/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
+++ b/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
@@ -58,6 +58,7 @@ import org.xmlpull.v1.XmlPullParserFactory;
 public class NativeNavigationPlugin extends Plugin {
 
     private static final int DEFAULT_NAVBAR_DP = 56;
+    // Android uses Material bottom navigation metrics; web/iOS keep their own platform-native tab bar heights.
     private static final int DEFAULT_TABBAR_DP = 80;
     private static final int TABBAR_ICON_DP = 24;
     private static final int TABBAR_ITEM_VERTICAL_PADDING_DP = 8;

--- a/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
+++ b/android/src/main/java/app/capgo/nativenavigation/NativeNavigationPlugin.java
@@ -58,7 +58,11 @@ import org.xmlpull.v1.XmlPullParserFactory;
 public class NativeNavigationPlugin extends Plugin {
 
     private static final int DEFAULT_NAVBAR_DP = 56;
-    private static final int DEFAULT_TABBAR_DP = 64;
+    private static final int DEFAULT_TABBAR_DP = 80;
+    private static final int TABBAR_ICON_DP = 24;
+    private static final int TABBAR_ITEM_VERTICAL_PADDING_DP = 8;
+    private static final int TABBAR_INDICATOR_DP = 32;
+    private static final int TABBAR_INDICATOR_LABEL_PADDING_DP = 4;
     private static final int DEFAULT_TRANSITION_MS = 350;
     private static final int MENU_ITEM_BASE = 10_000;
 
@@ -635,6 +639,12 @@ public class NativeNavigationPlugin extends Plugin {
 
         tabbar = new BottomNavigationView(getContext());
         tabbar.setElevation(0);
+        tabbar.setMinimumHeight(dp(DEFAULT_TABBAR_DP));
+        tabbar.setItemIconSize(dp(TABBAR_ICON_DP));
+        tabbar.setItemPaddingTop(dp(TABBAR_ITEM_VERTICAL_PADDING_DP));
+        tabbar.setItemPaddingBottom(dp(TABBAR_ITEM_VERTICAL_PADDING_DP));
+        tabbar.setItemActiveIndicatorHeight(dp(TABBAR_INDICATOR_DP));
+        tabbar.setActiveIndicatorLabelPadding(dp(TABBAR_INDICATOR_LABEL_PADDING_DP));
         tabbar.setBackgroundColor(Color.TRANSPARENT);
         tabbar.setOnItemSelectedListener((item) -> {
             int itemId = item.getItemId();


### PR DESCRIPTION
## Summary
- increase Android native tab bar host height to match Material bottom navigation layout needs
- explicitly set icon size, vertical item padding, active indicator height, and label spacing to prevent icon/label overlap

Fixes #24

## Tests
- bun run verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar visual appearance and spacing with refined sizing for icons, padding, and active indicators for better consistency across the navigation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->