### PR TITLE
docs: add curved tabbar screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Native navbar, tabbar, safe-area handling, and WebView snapshot transitions for 
 | --- | --- |
 | <img src="./docs/native-liquid-glass-ios.webp" alt="iOS native Liquid Glass navbar and tabbar screenshot" width="260" /> | <img src="./docs/native-liquid-glass-android.webp" alt="Android Liquid Glass-style native navbar and tabbar screenshot" width="260" /> |
 
+### Curved native tabbar screenshot
+
+<img
+  src="./docs/native-screenshots/android-curved-tabbar.png"
+  alt="Android native curved tabbar with raised center camera action and side margin"
+  width="300"
+/>
+
 ## Features
 
 - Drive native top navigation and bottom tabs from JavaScript state.


### PR DESCRIPTION
## Summary
- add the native Android curved tabbar screenshot to the README demo section
- reuse the verified screenshot already tracked in docs/native-screenshots

## Tests
- git diff --check